### PR TITLE
Add support for creating logins with known SID

### DIFF
--- a/internal/services/sqlLogin/resource.go
+++ b/internal/services/sqlLogin/resource.go
@@ -3,13 +3,14 @@ package sqlLogin
 import (
 	"context"
 	"fmt"
+	"strconv"
+
 	"github.com/PGSSoft/terraform-provider-mssql/internal/core/resource"
 	common2 "github.com/PGSSoft/terraform-provider-mssql/internal/services/common"
 	"github.com/PGSSoft/terraform-provider-mssql/internal/validators"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"strconv"
 
 	"github.com/PGSSoft/terraform-provider-mssql/internal/sql"
 	"github.com/PGSSoft/terraform-provider-mssql/internal/utils"
@@ -40,6 +41,7 @@ func (d resourceData) toSettings(ctx context.Context) sql.SqlLoginSettings {
 	}
 
 	return sql.SqlLoginSettings{
+		Id:                      d.Id.ValueString(),
 		Name:                    d.Name.ValueString(),
 		Password:                d.Password.ValueString(),
 		MustChangePassword:      d.MustChangePassword.ValueBool(),
@@ -93,7 +95,7 @@ func (r *res) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource
 	resp.Schema.Attributes = map[string]schema.Attribute{
 		"id": schema.StringAttribute{
 			MarkdownDescription: attrDescriptions["id"],
-			Computed:            true,
+			Optional:            true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
 			},

--- a/internal/sql/sqlLogin.go
+++ b/internal/sql/sqlLogin.go
@@ -12,6 +12,7 @@ import (
 const NullLoginId LoginId = "<null>"
 
 type SqlLoginSettings struct {
+	Id                      string
 	Name                    string
 	Password                string
 	MustChangePassword      bool
@@ -30,6 +31,10 @@ func (s SqlLoginSettings) toSqlOptions(ctx context.Context, conn Connection) str
 
 	builder := strings.Builder{}
 	builder.WriteString(fmt.Sprintf("PASSWORD='%s'", s.Password))
+
+	if s.Id != "" {
+		builder.WriteString(fmt.Sprintf(", SID=%s", s.Id))
+	}
 
 	if s.MustChangePassword && !isAzure {
 		builder.WriteString(" MUST_CHANGE")

--- a/internal/sql/sqlLogin_test.go
+++ b/internal/sql/sqlLogin_test.go
@@ -99,6 +99,11 @@ func (s *SqlLoginTestSuite) TestCreateSqlLogin() {
 			edition:  EDITION_ENTERPRISE,
 			sql:      "CREATE LOGIN [default_language] WITH PASSWORD='test_password', DEFAULT_LANGUAGE=[test_language], CHECK_EXPIRATION=OFF, CHECK_POLICY=ON",
 		},
+		"login with SID": {
+			settings: SqlLoginSettings{Name: "login_with_sid", Password: "test_password", Id: "0xE0EEDFAEC6DD7443BBFDE477C0D1E8A1"},
+			edition:  EDITION_ENTERPRISE,
+			sql:      "CREATE LOGIN [login_with_sid] WITH PASSWORD='test_password', SID=0xE0EEDFAEC6DD7443BBFDE477C0D1E8A1, CHECK_EXPIRATION=OFF, CHECK_POLICY=OFF",
+		},
 		"Azure SQL": {
 			settings: SqlLoginSettings{
 				Name:                    "default_language",


### PR DESCRIPTION
This PR makes the ID optional (from read only) so that it can be specified when creating a new login. Fixes #130

Note: I'm not a Go developer and this is my first Terraform provider contribution. I'm sure there is need for improvements.